### PR TITLE
fix: Catch File Exceptions thrown during the File Migration process

### DIFF
--- a/SpotifyDownloader/Services/FileManagmentService.cs
+++ b/SpotifyDownloader/Services/FileManagmentService.cs
@@ -108,8 +108,9 @@ public class FileManagmentService(ILogger<FileManagmentService> logger) : IFileM
                 return;
             }
             var albumsToOrganize = Directory.GetFiles(artistPath, "*", SearchOption.TopDirectoryOnly)
-                .Select(x => TagLib.File.Create(x))
-                .GroupBy(x => x.Tag.Album)
+                .Select(x => Fluents.Fluent.Try(() => TagLib.File.Create(x)).Ignore().Execute<TagLib.File?>())
+                .Where(x => x is not null)
+                .GroupBy(x => x!.Tag.Album)
                 .Where(x => x.Count() > 1) // Avoid singles
                 .ToDictionary(x => x.Key, x => x.Select(x => Path.GetFileName(x.Name)).ToList());
             

--- a/SpotifyDownloader/Utils/DirectoryUtils.cs
+++ b/SpotifyDownloader/Utils/DirectoryUtils.cs
@@ -1,8 +1,10 @@
-﻿namespace SpotifyDownloader.Utils;
+﻿using Microsoft.Extensions.Logging;
+
+namespace SpotifyDownloader.Utils;
 
 public static class DirectoryUtils
 {
-    public static void MoveAndMerge(string sourceDir, string destinationDir)
+    public static void MoveAndMerge(string sourceDir, string destinationDir, ILogger? logger = null)
     {
         if (!Directory.Exists(destinationDir))
         {
@@ -11,16 +13,23 @@ public static class DirectoryUtils
 
         foreach (var sourceFilePath in Directory.GetFiles(sourceDir, "*", SearchOption.AllDirectories))
         {
-            string relativePath = Path.GetRelativePath(sourceDir, sourceFilePath);
-            string destinationFilePath = Path.Combine(destinationDir, relativePath);
-
-            var destinationSubDir = Path.GetDirectoryName(destinationFilePath);
-            if (destinationSubDir != null && !Directory.Exists(destinationSubDir))
+            try
             {
-                Directory.CreateDirectory(destinationSubDir);
-            }
+                string relativePath = Path.GetRelativePath(sourceDir, sourceFilePath);
+                string destinationFilePath = Path.Combine(destinationDir, relativePath);
 
-            File.Copy(sourceFilePath, destinationFilePath, true);
+                var destinationSubDir = Path.GetDirectoryName(destinationFilePath);
+                if (destinationSubDir != null && !Directory.Exists(destinationSubDir))
+                {
+                    Directory.CreateDirectory(destinationSubDir);
+                }
+
+                File.Copy(sourceFilePath, destinationFilePath, true);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "An error occurred while moving the file \"{file}\" from \"{dirFrom}\" to \"{dirTo}\"", sourceFilePath, sourceDir, destinationDir);
+            }
         }
 
         Directory.Delete(sourceDir, true);


### PR DESCRIPTION
Tonight I set up a real case execution to test the next release, and two exceptions occurred.

## 1. `DirectoryNotFoundException` while moving an Artist

```
2024-10-15 00:30:05.571 +02:00 [ERR] An error occurred while moving <Artist>.
System.IO.DirectoryNotFoundException: Could not find a part of the path '/music/<Artist>/<Track>.opus'.
   at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirError)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, UnixFileMode openPermissions, Int64& fileLength, UnixFileMode& filePermissions, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException)
   at System.IO.FileSystem.CopyFile(String sourceFullPath, String destFullPath, Boolean overwrite)
   at SpotifyDownloader.Utils.DirectoryUtils.MoveAndMerge(String sourceDir, String destinationDir) in /src/SpotifyDownloader/Utils/DirectoryUtils.cs:line 23
   at SpotifyDownloader.Services.FileManagmentService.<>c__DisplayClass2_0.<MigrateFromOlderVersion>g__MoveItem|7(String destinationDirectory, String item) in /src/SpotifyDownloader/Services/FileManagmentService.cs:line 69
```

I'm not sure why the track couldn't be found, but this issue should not prevent the rest of the files from being moved.

## 2. `FileNotFoundException` while creating the TagLib File

Also this exception happened and in this case it stopped the program completely:

```
Unhandled exception. System.AggregateException: One or more errors occurred. (Could not find file '<Track>.opus'.)
 ---> System.IO.FileNotFoundException: Could not find file '<Track>.opus'.
File name: '<Track>.opus'
   at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirError)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, UnixFileMode openPermissions, Int64& fileLength, UnixFileMode& filePermissions, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
   at System.IO.File.Open(String path, FileMode mode, FileAccess access, FileShare share)
   at TagLib.File.LocalFileAbstraction.get_ReadStream()
   at TagLib.File.set_Mode(AccessMode value)
   at TagLib.Ogg.File..ctor(IFileAbstraction abstraction, ReadStyle propertiesStyle)
   at InvokeStub_File..ctor(Object, Span`1)
   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)   at TagLib.File.Create(IFileAbstraction abstraction, String mimetype, ReadStyle propertiesStyle)
   at System.Linq.Enumerable.SelectArrayIterator`2.MoveNext()
   at System.Linq.Lookup`2.Create(IEnumerable`1 source, Func`2 keySelector, IEqualityComparer`1 comparer)
   at System.Linq.GroupedEnumerable`2.GetEnumerator()
   at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
   at SpotifyDownloader.Services.FileManagmentService.<OrganizeArtists>g__OrganizeArtist|3_1(String artistName) in /src/SpotifyDownloader/Services/FileManagmentService.cs:line 110
   at SpotifyDownloader.Services.FileManagmentService.<>c__DisplayClass3_0.<OrganizeArtists>b__2() in /src/SpotifyDownloader/Services/FileManagmentService.cs:line 85
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.WaitAllCore(Task[] tasks, Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.WaitAll(Task[] tasks)
   at System.Threading.Tasks.Parallel.Invoke(ParallelOptions parallelOptions, Action[] actions)
--- End of stack trace from previous location ---
   at System.Threading.Tasks.Parallel.Invoke(ParallelOptions parallelOptions, Action[] actions)
   at SpotifyDownloader.Services.FileManagmentService.OrganizeArtists(IEnumerable`1 artistsNames) in /src/SpotifyDownloader/Services/FileManagmentService.cs:line 87
   at SpotifyDownloader.Services.FileManagmentService.MigrateFromOlderVersion(TrackingInformation trackingInformation) in /src/SpotifyDownloader/Services/FileManagmentService.cs:line 37
   at SpotifyDownloader.Helpers.CronJob.DoWork(CancellationToken cancellationToken) in /src/SpotifyDownloader/Helpers/CronJob.cs:line 17
   at EasyCronJob.Abstractions.CronJobService.<>c__DisplayClass5_0.<<ScheduleJob>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_1(Object state)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
```

This is also strange because `Directory.GetFiles` seems to return a file that `TagLib.File.Create` fails to open. I suspect this might be a random error, so to prevent this from stopping the program, I'll catch and log exceptions from TagLib without stopping the migration process. This will ensure that the error doesn't block other operations while maintaining traceability for future debugging.