### PR TITLE
fix: Remove parallelism in file management to prevent OOM issues

### DIFF
--- a/SpotifyDownloader/Helpers/CronJob.cs
+++ b/SpotifyDownloader/Helpers/CronJob.cs
@@ -5,7 +5,7 @@ using SpotifyDownloader.Services;
 namespace SpotifyDownloader.Helpers;
 
 public class CronJob(ICronConfiguration<CronJob> cronConfiguration, ILogger<CronJob> logger,
-    IFileManagmentService fileManagmentService, ITrackingService trackingService, IDownloadingService downloadingService,
+    IFileManagementService fileManagmentService, ITrackingService trackingService, IDownloadingService downloadingService,
     IArtistsService artistsService)
     : CronJobService(cronConfiguration.CronExpression, cronConfiguration.TimeZoneInfo, cronConfiguration.CronFormat)
 {

--- a/SpotifyDownloader/Program.cs
+++ b/SpotifyDownloader/Program.cs
@@ -90,7 +90,7 @@ IHost Build()
 
         x.AddDbContext<ApplicationDbContext>();
 
-        x.AddSingleton<IFileManagmentService, FileManagmentService>();
+        x.AddSingleton<IFileManagementService, FileManagementService>();
         x.AddSingleton<ITrackingService, TrackingService>();
         x.AddSingleton<IDownloadingService, DownloadingService>();
         x.AddScoped<IArtistsService, ArtistsService>();

--- a/SpotifyDownloader/Services/FileManagementService.cs
+++ b/SpotifyDownloader/Services/FileManagementService.cs
@@ -5,7 +5,7 @@ using SpotifyDownloader.Utils;
 
 namespace SpotifyDownloader.Services;
 
-public interface IFileManagmentService
+public interface IFileManagementService
 {
     /// <summary>
     /// If we have just upgraded from v2.0.0 or lower, move each artist and playlist to their corresponding subfolder.
@@ -17,7 +17,7 @@ public interface IFileManagmentService
     void OrganizeArtists(IEnumerable<string> artistsNames);
 }
 
-public class FileManagmentService(ILogger<FileManagmentService> logger) : IFileManagmentService
+public class FileManagementService(ILogger<FileManagementService> logger) : IFileManagementService
 {
     public void MigrateFromOlderVersion(TrackingInformation trackingInformation)
     {

--- a/SpotifyDownloader/Services/FileManagmentService.cs
+++ b/SpotifyDownloader/Services/FileManagmentService.cs
@@ -29,10 +29,8 @@ public class FileManagmentService(ILogger<FileManagmentService> logger) : IFileM
             .Where(x => x.FullPath != GlobalConfiguration.ARTISTS_DIRECTORY && x.FullPath != GlobalConfiguration.PLAYLISTS_DIRECTORY)
             .ToList();
 
-        Parallel.Invoke(
-            () => Move(trackingInformation.Artists, GlobalConfiguration.ARTISTS_DIRECTORY),
-            () => Move(trackingInformation.Playlists, GlobalConfiguration.PLAYLISTS_DIRECTORY)
-        );
+        Move(trackingInformation.Artists, GlobalConfiguration.ARTISTS_DIRECTORY);
+        Move(trackingInformation.Playlists, GlobalConfiguration.PLAYLISTS_DIRECTORY);
 
         OrganizeArtists(trackingInformation.Artists.Select(x => x.Name));
 
@@ -50,12 +48,10 @@ public class FileManagmentService(ILogger<FileManagmentService> logger) : IFileM
             }
 
             logger.LogInformation("Moving {num} items to \"{dir}\"...", itemsToMove.Count(), destinationDirectory);
-            var actions = new List<Action>();
             foreach (var item in itemsToMove.Select(x => x.Name))
             {
-                actions.Add(() => MoveItem(destinationDirectory, item));
+                MoveItem(destinationDirectory, item);
             }
-            Parallel.Invoke([.. actions]);
 
             void MoveItem(string destinationDirectory, string item)
             {
@@ -79,12 +75,10 @@ public class FileManagmentService(ILogger<FileManagmentService> logger) : IFileM
 
     public void OrganizeArtists(IEnumerable<string> artistsNames)
     {
-        var actions = new List<Action>();
         foreach (var artist in artistsNames)
         {
-            actions.Add(() => OrganizeArtist(artist));
+            OrganizeArtist(artist);
         }
-        Parallel.Invoke([.. actions]);
 
         // In case something went wrong, delete empty directories
         var emptyDirectories = Directory.GetDirectories(GlobalConfiguration.ARTISTS_DIRECTORY, "*", SearchOption.AllDirectories)


### PR DESCRIPTION
Processing artists in parallel in the `MigrateFromOlderVersion` method caused the container to be killed by the OOM Killer. Since this process will only be run once and I don't want to risk the whole program because of it, I will roll back the parallelism and make this part sequential.