### PR TITLE
fix: Match local tracks to remote playlist using metadata instead of filename

### DIFF
--- a/SpotifyDownloader/Services/PlaylistsService.cs
+++ b/SpotifyDownloader/Services/PlaylistsService.cs
@@ -83,13 +83,15 @@ public class PlaylistsService(ILogger<ArtistsService> logger, ISpotifyClientWrap
         List<string> missingTracks = [];
         foreach (var file in local)
         {
-            var fullPath = file.Name;
-            var fileName = Path.GetFileNameWithoutExtension(fullPath);
-            var remoteTrack = remote
-                .FirstOrDefault(x => fileName == $"{string.Join(", ", x.Track.Artists.Select(x => x.Name))} - {x.Track.Name}");
+            var existsRemoteTrack = remote
+                .Any(x =>
+                    x.Track.Artists.Select(x => x.Name).ToHashSet().SetEquals(file.Tag.Performers)
+                    && x.Track.Name == file.Tag.Title);
             
-            if (remoteTrack is null)
+            if (!existsRemoteTrack)
             {
+                var fullPath = file.Name;
+                var fileName = Path.GetFileNameWithoutExtension(fullPath);
                 logger.LogInformation("The track \"{track}\" has been marked for deletion as it is no longer present in the remote playlist.", fileName);
                 missingTracks.Add(fullPath);
             }


### PR DESCRIPTION
Some local tracks were not correctly detected as present in the remote playlist due to filename discrepancies caused by special characters (e.g., "?"). These characters are often stripped or altered in the filesystem but remain intact in the track's metadata. This fix changes the matching logic to rely on the track's Title and Performer tags (via TagLib) instead of the filename.
