### PR TITLE
Refactor process timeout handling in `DownloadingService` to prevent process leakage

### DIFF
--- a/SpotifyDownloader/Services/DownloadingService.cs
+++ b/SpotifyDownloader/Services/DownloadingService.cs
@@ -270,17 +270,29 @@ public class DownloadingService(ILogger<DownloadingService> logger, GlobalConfig
             });
 
             // Wait for the process to finish or for the timeout to expire
-            if (await Task.WhenAny(exitTask, Task.Delay(-1, cts.Token)) == exitTask)
+            try
             {
                 // The process finished
                 await exitTask;
-                await Task.WhenAll(outputReadingTask, errorReadingTask); // Ensure output was logged
             }
-            else
+            catch (OperationCanceledException) when (cts.IsCancellationRequested)
             {
                 // Timeout
-                process.Kill();
+                Try(() =>
+                {
+                    if (!process.HasExited)
+                        process.Kill(entireProcessTree: true);
+                }).Ignore().Execute();
+
                 throw new TimeoutException("Process timeout: spotdl took too long and was terminated.");
+            }
+            finally
+            {
+                try
+                {
+                    await Task.WhenAll(outputReadingTask, errorReadingTask); // Ensure output was logged
+                }
+                catch { /* Ignore */ }
             }
         }
 


### PR DESCRIPTION
This PR refactors the process waiting logic in `DownloadingService` to fix an issue where processes exceeding the maximum execution time were not being terminated, leading to **process leakage**.

### Root cause:

The previous implementation used:

```csharp
if (await Task.WhenAny(exitTask, Task.Delay(-1, cts.Token)) == exitTask)
```

However, when the timeout `CancellationToken` expired, `WaitForExitAsync(cts.Token)` would complete in a *canceled* state.
Since `Task.WhenAny` treats any completion (successful, faulted, or canceled) as “finished,” `exitTask` would always appear to complete first.
As a result, the timeout branch was never taken, and the process was left running in the background indefinitely, causing **orphaned processes**.

---

### Changes:

* Replaced the `Task.WhenAny` pattern with a `try/catch` around `WaitForExitAsync` that catches `OperationCanceledException` specifically when triggered by the timeout `CancellationTokenSource`.
* Added `process.Kill(entireProcessTree: true)` to ensure that all child processes (e.g., `ffmpeg` spawned by `spotdl`) are terminated along with the main process.
* Moved `await Task.WhenAll(outputReadingTask, errorReadingTask)` into a `finally` block to ensure stdout/stderr are always drained, even after termination.
* Wrapped the output/error reading task completion in a `try/catch` to avoid masking the main exception (such as `TimeoutException`) if a logging task fails.

---

### Benefits:

* **Fixes process leakage:** reliably kills any process running longer than 10 minutes, including child processes.
* Prevents leaving orphaned processes consuming system resources after timeout.
* Preserves complete stdout/stderr logging even if the process is terminated.
* Simplifies and clarifies the control flow.