### PR TITLE
Remove redundant service interfaces

### DIFF
--- a/SpotCrate/Helpers/CronJob.cs
+++ b/SpotCrate/Helpers/CronJob.cs
@@ -6,8 +6,8 @@ using SpotCrate.Services;
 namespace SpotCrate.Helpers;
 
 public class CronJob(ICronConfiguration<CronJob> cronConfiguration, ILogger<CronJob> logger, IServiceScopeFactory scopeFactory,
-    ITrackingService trackingService, IYtDlpService ytDlpService,
-    IFileOperationCoordinator fileOperationCoordinator)
+    TrackingService trackingService, YtDlpService ytDlpService,
+    FileOperationCoordinator fileOperationCoordinator)
     : CronJobService(cronConfiguration.CronExpression, cronConfiguration.TimeZoneInfo, cronConfiguration.CronFormat)
 {
     public override async Task DoWork(CancellationToken cancellationToken)
@@ -18,8 +18,8 @@ public class CronJob(ICronConfiguration<CronJob> cronConfiguration, ILogger<Cron
             await ytDlpService.EnsureReadyForRun(cancellationToken);
 
             using var scope = scopeFactory.CreateScope();
-            var downloadingService = scope.ServiceProvider.GetRequiredService<IDownloadingService>();
-            var artistsService = scope.ServiceProvider.GetRequiredService<IArtistsService>();
+            var downloadingService = scope.ServiceProvider.GetRequiredService<DownloadingService>();
+            var artistsService = scope.ServiceProvider.GetRequiredService<ArtistsService>();
 
             var result = await fileOperationCoordinator.RunWithExclusiveMusicAccess(async () =>
             {

--- a/SpotCrate/Pages/Index.cshtml.cs
+++ b/SpotCrate/Pages/Index.cshtml.cs
@@ -6,7 +6,7 @@ using SpotCrate.Services;
 
 namespace SpotCrate.Pages;
 
-public class IndexModel(ITrackingEditorService trackingEditorService) : PageModel
+public class IndexModel(TrackingEditorService trackingEditorService) : PageModel
 {
     public TrackingInformation TrackingInformation { get; private set; } = new();
     public bool IsTrackingFileWritable { get; private set; }

--- a/SpotCrate/Program.cs
+++ b/SpotCrate/Program.cs
@@ -48,7 +48,7 @@ try
         await dbContext.Database.MigrateAsync();
     }
 
-    var appVersionMigrationService = scope.ServiceProvider.GetRequiredService<IAppVersionMigrationService>();
+    var appVersionMigrationService = scope.ServiceProvider.GetRequiredService<AppVersionMigrationService>();
     await appVersionMigrationService.MigrateToCurrentVersion();
 
     logger.LogInformation("Cron job configured with: \"{cron}\"", CRON_SCHEDULE);
@@ -124,16 +124,16 @@ WebApplication Build()
             SPOTIFY_CLIENT_ID,
             SPOTIFY_CLIENT_SECRET));
     builder.Services.AddSingleton(new SpotifyClient(config));
-    builder.Services.AddScoped<ISpotifyClientWrapper, SpotifyClientWrapper>();
+    builder.Services.AddScoped<SpotifyClientWrapper>();
 
-    builder.Services.AddSingleton<IFileManagementService, FileManagementService>();
-    builder.Services.AddSingleton<IFileOperationCoordinator, FileOperationCoordinator>();
-    builder.Services.AddSingleton<ITrackingService, TrackingService>();
-    builder.Services.AddSingleton<ITrackingEditorService, TrackingEditorService>();
-    builder.Services.AddScoped<IAppVersionMigrationService, AppVersionMigrationService>();
-    builder.Services.AddScoped<IDownloadingService, DownloadingService>();
-    builder.Services.AddSingleton<IYtDlpService, YtDlpService>();
-    builder.Services.AddScoped<IArtistsService, ArtistsService>();
+    builder.Services.AddSingleton<FileManagementService>();
+    builder.Services.AddSingleton<FileOperationCoordinator>();
+    builder.Services.AddSingleton<TrackingService>();
+    builder.Services.AddSingleton<TrackingEditorService>();
+    builder.Services.AddScoped<AppVersionMigrationService>();
+    builder.Services.AddScoped<DownloadingService>();
+    builder.Services.AddSingleton<YtDlpService>();
+    builder.Services.AddScoped<ArtistsService>();
     builder.Services.AddScoped<PlaylistsService>();
 
     builder.Services.ApplyResulation<CronJob>(options =>

--- a/SpotCrate/Services/AppVersionMigrationService.cs
+++ b/SpotCrate/Services/AppVersionMigrationService.cs
@@ -5,14 +5,9 @@ using SpotCrate.Helpers;
 
 namespace SpotCrate.Services;
 
-public interface IAppVersionMigrationService
-{
-    Task MigrateToCurrentVersion(CancellationToken cancellationToken = default);
-}
-
-public class AppVersionMigrationService(ApplicationDbContext dbContext, IFileManagementService fileManagementService,
-    ITrackingService trackingService, IFileOperationCoordinator fileOperationCoordinator,
-    ILogger<AppVersionMigrationService> logger) : IAppVersionMigrationService
+public class AppVersionMigrationService(ApplicationDbContext dbContext, FileManagementService fileManagementService,
+    TrackingService trackingService, FileOperationCoordinator fileOperationCoordinator,
+    ILogger<AppVersionMigrationService> logger)
 {
     public async Task MigrateToCurrentVersion(CancellationToken cancellationToken = default)
     {

--- a/SpotCrate/Services/ArtistsService.cs
+++ b/SpotCrate/Services/ArtistsService.cs
@@ -7,16 +7,7 @@ using static Fluents.Fluent;
 
 namespace SpotCrate.Services;
 
-public interface IArtistsService
-{
-    Task<(string[] localTracks, string[] localAlbums)> GetLocalArtistInfo(string artistName);
-
-    Task<SimpleAlbum[]> GetRemoteArtistInfo(string url);
-
-    Task UpdateLocalArtistsInfo();
-}
-
-public class ArtistsService(ISpotifyClientWrapper spotifyClient, ApplicationDbContext _applicationDbContext) : IArtistsService
+public class ArtistsService(SpotifyClientWrapper spotifyClient, ApplicationDbContext _applicationDbContext)
 {
     public async Task<(string[] localTracks, string[] localAlbums)> GetLocalArtistInfo(string artistName)
     {

--- a/SpotCrate/Services/DownloadingService.cs
+++ b/SpotCrate/Services/DownloadingService.cs
@@ -10,15 +10,9 @@ using static Fluents.Fluent;
 
 namespace SpotCrate.Services;
 
-public interface IDownloadingService
-{
-    Task<DownloadResult> Download(TrackingInformation trackingInformation);
-    Task<DownloadResult> DownloadWithoutFileOperationLock(TrackingInformation trackingInformation);
-}
-
 public class DownloadingService(ILogger<DownloadingService> logger, GlobalConfiguration configuration,
-    ISpotifyClientWrapper spotifyClient, IArtistsService artistsService, PlaylistsService playlistsService,
-    IFileOperationCoordinator fileOperationCoordinator) : IDownloadingService
+    SpotifyClientWrapper spotifyClient, ArtistsService artistsService, PlaylistsService playlistsService,
+    FileOperationCoordinator fileOperationCoordinator)
 {
     private static readonly string[] SpotdlFailureMarkers =
     [

--- a/SpotCrate/Services/FileManagementService.cs
+++ b/SpotCrate/Services/FileManagementService.cs
@@ -6,25 +6,11 @@ using SpotCrate.Utils;
 
 namespace SpotCrate.Services;
 
-public interface IFileManagementService
+public class FileManagementService(ILogger<FileManagementService> logger)
 {
     /// <summary>
     /// If we have just upgraded from v2.0.0 or lower, move each artist and playlist to their corresponding subfolder.
     /// </summary>
-    void MigrateFromOlderVersion(TrackingInformation trackingInformation, AppVersion upgradeFrom);
-    /// <summary>
-    /// Groups tracks by albums in the file system. If an album only has one track, it won't be moved.
-    /// </summary>
-    void OrganizeArtists(IEnumerable<string> artistsNames);
-
-    /// <summary>
-    /// Renames the local directory for a tracked artist or playlist.
-    /// </summary>
-    void RenameTrackedItemDirectory(TrackingEntryType entryType, string oldName, string newName);
-}
-
-public class FileManagementService(ILogger<FileManagementService> logger) : IFileManagementService
-{
     public void MigrateFromOlderVersion(TrackingInformation trackingInformation, AppVersion upgradeFrom)
     {
         if (upgradeFrom < new AppVersion(2, 1, 2))
@@ -90,7 +76,7 @@ public class FileManagementService(ILogger<FileManagementService> logger) : IFil
                 }
             }
         }
-        
+
         void Migration_2_3_1()
         {
             // Fixes https://github.com/pjmeca/spotcrate/issues/36
@@ -131,6 +117,9 @@ public class FileManagementService(ILogger<FileManagementService> logger) : IFil
         }
     }
 
+    /// <summary>
+    /// Groups tracks by albums in the file system. If an album only has one track, it won't be moved.
+    /// </summary>
     public void OrganizeArtists(IEnumerable<string> artistsNames)
     {
         foreach (var artist in artistsNames)
@@ -199,6 +188,9 @@ public class FileManagementService(ILogger<FileManagementService> logger) : IFil
         }
     }
 
+    /// <summary>
+    /// Renames the local directory for a tracked artist or playlist.
+    /// </summary>
     public void RenameTrackedItemDirectory(TrackingEntryType entryType, string oldName, string newName)
     {
         var sanitizedOldName = oldName.ToValidPathString();

--- a/SpotCrate/Services/FileOperationCoordinator.cs
+++ b/SpotCrate/Services/FileOperationCoordinator.cs
@@ -1,12 +1,6 @@
 namespace SpotCrate.Services;
 
-public interface IFileOperationCoordinator
-{
-    Task<TResult> RunWithExclusiveMusicAccess<TResult>(Func<Task<TResult>> operation, CancellationToken cancellationToken = default);
-    Task<(bool Acquired, TResult? Result)> TryRunWithExclusiveMusicAccess<TResult>(Func<Task<TResult>> operation, CancellationToken cancellationToken = default);
-}
-
-public class FileOperationCoordinator : IFileOperationCoordinator
+public class FileOperationCoordinator
 {
     private readonly SemaphoreSlim semaphore = new(1, 1);
 

--- a/SpotCrate/Services/PlaylistsService.cs
+++ b/SpotCrate/Services/PlaylistsService.cs
@@ -10,7 +10,7 @@ using File = TagLib.File;
 
 namespace SpotCrate.Services;
 
-public class PlaylistsService(ILogger<ArtistsService> logger, ISpotifyClientWrapper spotifyClient, ApplicationDbContext _applicationDbContext)
+public class PlaylistsService(ILogger<ArtistsService> logger, SpotifyClientWrapper spotifyClient, ApplicationDbContext _applicationDbContext)
 {
     public File[] GetLocalPlaylistInfo(string playlistName)
     {

--- a/SpotCrate/Services/SpotifyClientWrapper.cs
+++ b/SpotCrate/Services/SpotifyClientWrapper.cs
@@ -7,19 +7,7 @@ namespace SpotCrate.Services;
 /// <summary>
 /// This is a wrapper for the SpotifyClient that adds control for TooManyRequests exceptions.
 /// </summary>
-public interface ISpotifyClientWrapper
-{
-    /// <inheritdoc cref="IArtistsClient.GetAlbums(string, CancellationToken)"/>>
-    Task<IList<SimpleAlbum>> GetAllAlbums(string artistId);
-
-    /// <inheritdoc cref="IAlbumsClient.GetTracks(string, CancellationToken)"/>>
-    Task<IList<SimpleTrack>> GetAllAlbumTracks(string albumId);
-
-    /// <inheritdoc cref="IPlaylistsClient.GetItems(string,System.Threading.CancellationToken)"/>>
-    public Task<IList<PlaylistTrack<IPlayableItem>>> GetAllPlaylistTracks(string playlistId);
-}
-
-public class SpotifyClientWrapper(ILogger<SpotifyClientWrapper> _logger, SpotifyClient _spotifyClient) : ISpotifyClientWrapper
+public class SpotifyClientWrapper(ILogger<SpotifyClientWrapper> _logger, SpotifyClient _spotifyClient)
 {
     private async Task<T> TooManyRequestsWrapper<T>(Func<Task<T>> func)
     {
@@ -39,6 +27,7 @@ public class SpotifyClientWrapper(ILogger<SpotifyClientWrapper> _logger, Spotify
         }
     }
 
+    /// <inheritdoc cref="IArtistsClient.GetAlbums(string, CancellationToken)"/>
     public async Task<IList<SimpleAlbum>> GetAllAlbums(string artistId)
     {
         return await TooManyRequestsWrapper(async () =>
@@ -54,6 +43,7 @@ public class SpotifyClientWrapper(ILogger<SpotifyClientWrapper> _logger, Spotify
         });
     }
 
+    /// <inheritdoc cref="IAlbumsClient.GetTracks(string, CancellationToken)"/>
     public async Task<IList<SimpleTrack>> GetAllAlbumTracks(string albumId)
     {
         return await TooManyRequestsWrapper(async () =>
@@ -65,6 +55,7 @@ public class SpotifyClientWrapper(ILogger<SpotifyClientWrapper> _logger, Spotify
         });
     }
 
+    /// <inheritdoc cref="IPlaylistsClient.GetItems(string,System.Threading.CancellationToken)"/>
     public Task<IList<PlaylistTrack<IPlayableItem>>> GetAllPlaylistTracks(string playlistId)
         => TooManyRequestsWrapper(async () =>
         {

--- a/SpotCrate/Services/TrackingEditorService.cs
+++ b/SpotCrate/Services/TrackingEditorService.cs
@@ -4,17 +4,8 @@ using SpotCrate.Utils;
 
 namespace SpotCrate.Services;
 
-public interface ITrackingEditorService
-{
-    Task<TrackingInformation> GetTrackingInformation(CancellationToken cancellationToken = default);
-    Task<bool> IsTrackingFileWritable(CancellationToken cancellationToken = default);
-    Task<TrackingEditorResult> SaveEntry(TrackingEntryInput input, CancellationToken cancellationToken = default);
-    Task<TrackingEditorResult> DeleteEntry(TrackingEntryType entryType, int index, string? originalName, string? originalUrl, CancellationToken cancellationToken = default);
-    Task<TrackingEditorResult> ReorderEntries(TrackingEntryType entryType, IReadOnlyList<int> orderedIndexes, IReadOnlyList<TrackingReorderEntryInput> orderedEntries, CancellationToken cancellationToken = default);
-}
-
-public class TrackingEditorService(ITrackingService trackingService, IFileManagementService fileManagementService,
-    IFileOperationCoordinator fileOperationCoordinator, ILogger<TrackingEditorService> logger) : ITrackingEditorService
+public class TrackingEditorService(TrackingService trackingService, FileManagementService fileManagementService,
+    FileOperationCoordinator fileOperationCoordinator, ILogger<TrackingEditorService> logger)
 {
     private const string DownloadInProgressMessage = "A download is currently in progress. Tracking changes are disabled until it finishes.";
     private const string RenameRollbackFailedMessage = "The local directory could not be renamed, and tracking.yaml could not be rolled back. Check the server logs before running the downloader again.";

--- a/SpotCrate/Services/TrackingService.cs
+++ b/SpotCrate/Services/TrackingService.cs
@@ -5,15 +5,7 @@ using YamlDotNet.Serialization.NamingConventions;
 
 namespace SpotCrate.Services;
 
-public interface ITrackingService
-{
-    Task<TrackingInformation> ReadTrackingInformation(string? trackingFile = null, CancellationToken cancellationToken = default);
-    Task WriteTrackingInformation(TrackingInformation trackingInformation, string? trackingFile = null, CancellationToken cancellationToken = default);
-    Task<TResult> UpdateTrackingInformation<TResult>(Func<TrackingInformation, (TResult Result, bool ShouldWrite)> update, string? trackingFile = null, CancellationToken cancellationToken = default);
-    Task<bool> IsTrackingFileWritable(string? trackingFile = null, CancellationToken cancellationToken = default);
-}
-
-public class TrackingService(ILogger<TrackingService> logger) : ITrackingService
+public class TrackingService(ILogger<TrackingService> logger)
 {
     public const string DEFAULT_TRACKING_FILE = "/app/tracking.yaml";
     private readonly SemaphoreSlim trackingFileSemaphore = new(1, 1);

--- a/SpotCrate/Services/YtDlpService.cs
+++ b/SpotCrate/Services/YtDlpService.cs
@@ -6,12 +6,7 @@ using static Fluents.Fluent;
 
 namespace SpotCrate.Services;
 
-public interface IYtDlpService
-{
-    Task EnsureReadyForRun(CancellationToken cancellationToken);
-}
-
-public class YtDlpService(ILogger<YtDlpService> logger, GlobalConfiguration configuration) : IYtDlpService
+public class YtDlpService(ILogger<YtDlpService> logger, GlobalConfiguration configuration)
 {
     private const string BeforeRunPolicy = "before-run";
     private const string NeverPolicy = "never";


### PR DESCRIPTION
## Summary

- Remove the nine service interfaces that only had a single implementation.
- Inject and register concrete service types while preserving their existing DI lifetimes.
- Move XML documentation from interfaces to the corresponding implementations.
- Fix malformed `<inheritdoc>` tags in `SpotifyClientWrapper`.

This reduces indirection and improves IDE navigation without changing application behavior.